### PR TITLE
Add NAND rule

### DIFF
--- a/src/Registry/Registry.php
+++ b/src/Registry/Registry.php
@@ -23,6 +23,7 @@ class Registry
         $this->add('or', new Container\OrRule());
         $this->add('xor', new Container\XorRule());
         $this->add('not', new Container\NotRule());
+        $this->add('nand', new Container\NandRule());
 
         $this->add('false', new Rule\FalseRule());
         $this->add('true', new Rule\TrueRule());

--- a/src/Rule/Container/NandRule.php
+++ b/src/Rule/Container/NandRule.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Dnoegel\Rules\Rule\Container;
+
+/**
+ * NandRule nagates the result of the AndRule
+ *
+ * Class NandRule
+ * @package Dnoegel\Rules\Rule\Container
+ */
+class NandRule extends AbstractContainer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate()
+    {
+        $andRule = $this->createAndRuleFromRules();
+
+        $rule = new NotRule($andRule);
+
+        return $rule->validate();
+    }
+
+    /**
+     * @return AndRule
+     */
+    private function createAndRuleFromRules()
+    {
+        $andRuleClass = 'Dnoegel\Rules\Rule\Container\AndRule';
+        // as of PHP 5.5 this can be replaced by:
+        // $andRuleClass = AndRule::class;
+
+        $reflect = new \ReflectionClass($andRuleClass);
+        $andRule = $reflect->newInstanceArgs($this->rules);
+
+        return $andRule;
+    }
+}

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -135,6 +135,35 @@ class RuleTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($rule->validate());
     }
 
+    /**
+     * Test logical NAND rule container
+     */
+    public function testNandRule()
+    {
+        $rule = $this->getRuleBuilder()->fromArray(array(
+            'false',
+            'false',
+        ), 'nand');
+        $this->assertTrue($rule->validate());
+
+        $rule = $this->getRuleBuilder()->fromArray(array(
+            'false',
+            'true',
+        ), 'nand');
+        $this->assertTrue($rule->validate());
+
+        $rule = $this->getRuleBuilder()->fromArray(array(
+            'true',
+            'false',
+        ), 'nand');
+        $this->assertTrue($rule->validate());
+
+        $rule = $this->getRuleBuilder()->fromArray(array(
+            'true',
+            'true',
+        ), 'nand');
+        $this->assertFalse($rule->validate());
+    }
 
     public function testCompareRule()
     {


### PR DESCRIPTION
Add the missing but most important NAND gate.

Could be simplified to just using the the AND validate method but I wanted to play around with the combining approach.

```
    public function validate()
    {
        foreach ($this->rules as $rule) {
            if (!$rule->validate()) {
                return true;
            }
        }

        return false;
    }
```

Maybe you should implement the NAND like shown above and just compose all the other logical rule by combining NANDs _justtrolling_ 
